### PR TITLE
Add 2 Way Media Gallery plugin

### DIFF
--- a/2-way-media-gallery/2-way-media-gallery.php
+++ b/2-way-media-gallery/2-way-media-gallery.php
@@ -1,0 +1,198 @@
+<?php
+/*
+Plugin Name: 2 Way Media Gallery
+Description: Upload and manage galleries with public links and folder structure.
+Version: 1.0.0
+Author: 2 Way Media
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+define( 'TWMG_DIR', plugin_dir_path( __FILE__ ) );
+define( 'TWMG_URL', plugin_dir_url( __FILE__ ) );
+
+class Two_Way_Media_Gallery {
+
+    public function __construct() {
+        add_shortcode( 'gallery_uploader', [ $this, 'render_gallery_page' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'wp_ajax_twmg_upload', [ $this, 'handle_upload' ] );
+        add_action( 'wp_ajax_nopriv_twmg_upload', [ $this, 'handle_upload' ] );
+        add_action( 'wp_ajax_twmg_list_galleries', [ $this, 'ajax_list_galleries' ] );
+        add_action( 'wp_ajax_twmg_get_gallery', [ $this, 'ajax_get_gallery' ] );
+        add_action( 'wp_ajax_twmg_delete_gallery', [ $this, 'ajax_delete_gallery' ] );
+        add_action( 'wp_ajax_twmg_regenerate_link', [ $this, 'ajax_regenerate_link' ] );
+    }
+
+    public function enqueue_assets() {
+        wp_enqueue_style( 'twmg-style', TWMG_URL . 'css/gallery-uploader.css' );
+        wp_enqueue_script( 'twmg-script', TWMG_URL . 'js/gallery-uploader.js', ['jquery'], null, true );
+        wp_localize_script( 'twmg-script', 'twmg', [
+            'ajax_url' => admin_url( 'admin-ajax.php' ),
+            'nonce'    => wp_create_nonce( 'twmg_nonce' ),
+            'is_admin' => current_user_can( 'manage_options' ),
+        ] );
+    }
+
+    public function render_gallery_page() {
+        ob_start();
+        ?>
+        <div class="twmg-tabs">
+            <ul class="twmg-tab-nav">
+                <li class="active" data-tab="upload">Upload</li>
+                <li data-tab="manage">Manage Folders</li>
+            </ul>
+            <div id="twmg-upload" class="twmg-tab-content active">
+                <h2>Upload Gallery</h2>
+                <input type="text" id="twmg-gallery-name" placeholder="Gallery Name" />
+                <div id="twmg-dropzone" class="twmg-dropzone">Drag & Drop Images Here</div>
+                <input type="file" id="twmg-file-input" multiple style="display:none;" />
+                <div id="twmg-progress"></div>
+                <button id="twmg-start-upload">Upload</button>
+                <div id="twmg-message"></div>
+            </div>
+            <div id="twmg-manage" class="twmg-tab-content">
+                <h2>Manage Folders</h2>
+                <div id="twmg-gallery-list"></div>
+            </div>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+
+    private function get_gallery_base() {
+        $upload = wp_upload_dir();
+        $base   = trailingslashit( $upload['basedir'] ) . 'twmg';
+        if ( ! file_exists( $base ) ) {
+            wp_mkdir_p( $base );
+        }
+        return $base;
+    }
+
+    public function handle_upload() {
+        check_ajax_referer( 'twmg_nonce', 'nonce' );
+
+        if ( empty( $_FILES['files'] ) || empty( $_POST['gallery'] ) ) {
+            wp_send_json_error( 'Missing data.' );
+        }
+
+        $gallery = sanitize_text_field( $_POST['gallery'] );
+        $base    = $this->get_gallery_base();
+
+        $path = $base . '/' . date('Y/m/d') . '/' . sanitize_title( $gallery );
+        wp_mkdir_p( $path );
+
+        foreach ( $_FILES['files']['name'] as $i => $name ) {
+            if ( $_FILES['files']['error'][$i] !== UPLOAD_ERR_OK ) {
+                continue;
+            }
+
+            $filename = wp_unique_filename( $path, $name );
+            move_uploaded_file( $_FILES['files']['tmp_name'][$i], $path . '/' . $filename );
+        }
+
+        // store gallery info
+        $galleries = get_option( 'twmg_galleries', [] );
+        $slug      = sanitize_title( $gallery );
+        $galleries[ $slug ] = [
+            'name' => $gallery,
+            'path' => $path,
+            'created' => current_time( 'timestamp' ),
+            'expires' => current_time( 'timestamp' ) + DAY_IN_SECONDS * 7,
+        ];
+        update_option( 'twmg_galleries', $galleries );
+
+        wp_send_json_success( 'Upload complete.' );
+    }
+
+    public function ajax_list_galleries() {
+        check_ajax_referer( 'twmg_nonce', 'nonce' );
+        $galleries = get_option( 'twmg_galleries', [] );
+        $out = [];
+        foreach ( $galleries as $slug => $data ) {
+            if ( $data['expires'] < current_time( 'timestamp' ) ) {
+                continue;
+            }
+            $url = content_url( str_replace( WP_CONTENT_DIR, '', $data['path'] ) );
+            $out[] = [ 'name' => $data['name'], 'slug' => $slug, 'url' => $url ];
+        }
+        wp_send_json_success( $out );
+    }
+
+    public function ajax_get_gallery() {
+        check_ajax_referer( 'twmg_nonce', 'nonce' );
+        $slug = sanitize_title( $_POST['slug'] ?? '' );
+        $galleries = get_option( 'twmg_galleries', [] );
+        if ( empty( $galleries[ $slug ] ) ) {
+            wp_send_json_error( 'Gallery not found' );
+        }
+        $path = $galleries[ $slug ]['path'];
+        $url  = content_url( str_replace( WP_CONTENT_DIR, '', $path ) );
+        $images = array_values( array_filter( scandir( $path ), function( $f ) {
+            return preg_match( '/\.(jpg|jpeg|png|gif)$/i', $f );
+        } ) );
+        $data = [
+            'name' => $galleries[ $slug ]['name'],
+            'images' => [],
+        ];
+        foreach ( $images as $img ) {
+            $data['images'][] = [
+                'src' => $url . '/' . $img,
+                'download' => $url . '/' . $img,
+            ];
+        }
+        wp_send_json_success( $data );
+    }
+
+    public function ajax_delete_gallery() {
+        check_ajax_referer( 'twmg_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Permission denied' );
+        }
+        $slug = sanitize_title( $_POST['slug'] ?? '' );
+        $galleries = get_option( 'twmg_galleries', [] );
+        if ( empty( $galleries[ $slug ] ) ) {
+            wp_send_json_error( 'Gallery not found' );
+        }
+        $path = $galleries[ $slug ]['path'];
+        $this->delete_folder( $path );
+        unset( $galleries[ $slug ] );
+        update_option( 'twmg_galleries', $galleries );
+        wp_send_json_success( 'Gallery deleted' );
+    }
+
+    public function ajax_regenerate_link() {
+        check_ajax_referer( 'twmg_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Permission denied' );
+        }
+        $slug = sanitize_title( $_POST['slug'] ?? '' );
+        $galleries = get_option( 'twmg_galleries', [] );
+        if ( empty( $galleries[ $slug ] ) ) {
+            wp_send_json_error( 'Gallery not found' );
+        }
+        $galleries[ $slug ]['expires'] = current_time( 'timestamp' ) + DAY_IN_SECONDS * 7;
+        update_option( 'twmg_galleries', $galleries );
+        wp_send_json_success( 'Link regenerated' );
+    }
+
+    private function delete_folder( $dir ) {
+        if ( ! file_exists( $dir ) ) {
+            return;
+        }
+        $files = array_diff( scandir( $dir ), ['.', '..'] );
+        foreach ( $files as $file ) {
+            $path = "$dir/$file";
+            if ( is_dir( $path ) ) {
+                $this->delete_folder( $path );
+            } else {
+                unlink( $path );
+            }
+        }
+        rmdir( $dir );
+    }
+}
+
+new Two_Way_Media_Gallery();

--- a/2-way-media-gallery/css/gallery-uploader.css
+++ b/2-way-media-gallery/css/gallery-uploader.css
@@ -1,0 +1,14 @@
+.twmg-tabs{max-width:900px;margin:auto;font-family:sans-serif}
+.twmg-tab-nav{list-style:none;padding:0;display:flex;border-bottom:2px solid #ccc}
+.twmg-tab-nav li{padding:10px 20px;cursor:pointer}
+.twmg-tab-nav li.active{border-bottom:3px solid #000;font-weight:bold}
+.twmg-tab-content{display:none;padding:20px}
+.twmg-tab-content.active{display:block}
+.twmg-dropzone{border:2px dashed #ccc;padding:40px;text-align:center;margin-bottom:20px}
+.twmg-gallery-grid{display:grid;grid-template-columns:1fr 1fr;grid-gap:10px}
+.twmg-gallery-item{position:relative}
+.twmg-like{position:absolute;left:5px;top:5px;background:#fff;padding:2px 5px;border-radius:3px;cursor:pointer}
+.twmg-download{position:absolute;right:5px;top:5px;background:#000;color:#fff;padding:2px 5px;border-radius:3px;text-decoration:none}
+.twmg-banner{text-align:center;margin-bottom:20px}
+.twmg-download-all{display:block;width:100%;max-width:300px;margin:20px auto;padding:10px;background:#000;color:#fff;text-align:center;text-decoration:none;font-weight:bold}
+@media(max-width:600px){.twmg-gallery-grid{grid-template-columns:1fr}}

--- a/2-way-media-gallery/js/gallery-uploader.js
+++ b/2-way-media-gallery/js/gallery-uploader.js
@@ -1,0 +1,141 @@
+jQuery(document).ready(function($){
+    var files = [];
+
+    $('.twmg-tab-nav li').on('click', function(){
+        var tab = $(this).data('tab');
+        $('.twmg-tab-nav li').removeClass('active');
+        $(this).addClass('active');
+        $('.twmg-tab-content').removeClass('active');
+        $('#twmg-' + tab).addClass('active');
+    });
+
+    $('#twmg-dropzone').on('click', function(){
+        $('#twmg-file-input').click();
+    });
+
+    $('#twmg-file-input').on('change', function(e){
+        files = this.files;
+        $('#twmg-progress').text(files.length + ' files ready to upload');
+    });
+
+    $('#twmg-dropzone').on('dragover', function(e){ e.preventDefault(); });
+    $('#twmg-dropzone').on('drop', function(e){
+        e.preventDefault();
+        files = e.originalEvent.dataTransfer.files;
+        $('#twmg-progress').text(files.length + ' files ready to upload');
+    });
+
+    $('#twmg-start-upload').on('click', function(){
+        var gallery = $('#twmg-gallery-name').val();
+        if(!gallery || files.length === 0){
+            alert('Gallery name and files required');
+            return;
+        }
+        var formData = new FormData();
+        $.each(files, function(i,file){ formData.append('files[]', file); });
+        formData.append('gallery', gallery);
+        formData.append('action', 'twmg_upload');
+        formData.append('nonce', twmg.nonce);
+        $.ajax({
+            url: twmg.ajax_url,
+            type: 'POST',
+            data: formData,
+            contentType: false,
+            processData: false,
+            xhr: function(){
+                var xhr = $.ajaxSettings.xhr();
+                if(xhr.upload){
+                    xhr.upload.addEventListener('progress', function(e){
+                        if(e.lengthComputable){
+                            var pct = Math.round((e.loaded / e.total) * 100);
+                            $('#twmg-progress').text(pct + '%');
+                        }
+                    }, false);
+                }
+                return xhr;
+            },
+            success: function(res){
+                if(res.success){
+                    $('#twmg-message').text(res.data);
+                    $('#twmg-progress').text('');
+                }else{
+                    $('#twmg-message').text(res.data || 'Upload failed');
+                }
+            }
+        });
+    });
+
+    function loadGalleries(){
+        $.post(twmg.ajax_url, {action:'twmg_list_galleries', nonce:twmg.nonce}, function(res){
+            if(res.success){
+                var list = $('<ul/>');
+                $.each(res.data, function(i,g){
+                    var li = $('<li/>').text(g.name).attr('data-slug', g.slug);
+                    if(twmg.is_admin){
+                        li.append(' <a href="#" class="twmg-del" data-slug="'+g.slug+'">Delete</a> <a href="#" class="twmg-reg" data-slug="'+g.slug+'">Regenerate Link</a>');
+                    }
+                    list.append(li);
+                });
+                $('#twmg-gallery-list').html(list);
+            }
+        });
+    }
+
+    $('#twmg-manage').on('click','li',function(){
+        var slug = $(this).data('slug');
+        $.post(twmg.ajax_url,{action:'twmg_get_gallery',slug:slug,nonce:twmg.nonce},function(res){
+            if(res.success){
+                var data = res.data;
+                var html = '<div class="twmg-banner"><h3>'+data.name+'</h3><p>By: 2 Way Media</p></div>';
+                html += '<div class="twmg-gallery-grid">';
+                $.each(data.images,function(i,img){
+                    html += '<div class="twmg-gallery-item"><img src="'+img.src+'" style="width:100%"/><span class="twmg-like">❤</span><a class="twmg-download" href="'+img.download+'" download>↓</a></div>';
+                });
+                html += '</div><a class="twmg-download-all" href="#" data-slug="'+slug+'">DOWNLOAD ALL PHOTOS</a>';
+                $('#twmg-gallery-list').html(html);
+            }
+        });
+    });
+
+    $(document).on('click','.twmg-download-all',function(e){
+        e.preventDefault();
+        var slug=$(this).data('slug');
+        $.post(twmg.ajax_url,{action:'twmg_get_gallery',slug:slug,nonce:twmg.nonce},function(res){
+            if(res.success){
+                $.each(res.data.images,function(i,img){
+                    var link=document.createElement('a');
+                    link.href=img.download;
+                    link.download='';
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                });
+            }
+        });
+    });
+
+    $(document).on('click','.twmg-del',function(e){
+        e.preventDefault();
+        var slug=$(this).data('slug');
+        if(!confirm('Delete gallery?')) return;
+        $.post(twmg.ajax_url,{action:'twmg_delete_gallery',slug:slug,nonce:twmg.nonce},function(res){
+            alert(res.data);
+            loadGalleries();
+        });
+    });
+
+    $(document).on('click','.twmg-reg',function(e){
+        e.preventDefault();
+        var slug=$(this).data('slug');
+        $.post(twmg.ajax_url,{action:'twmg_regenerate_link',slug:slug,nonce:twmg.nonce},function(res){
+            alert(res.data);
+        });
+    });
+
+    $(document).on('click','.twmg-like',function(){
+        var count=parseInt($(this).data('count')||0)+1;
+        $(this).data('count',count).text('❤ '+count);
+    });
+
+    loadGalleries();
+});

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Nashe
-Danger 
+This repository contains a sample WordPress plugin named **2 Way Media Gallery**.
+
+## Installing
+
+Copy the `2-way-media-gallery` directory into your WordPress `wp-content/plugins` folder and activate it from the WordPress admin panel.
+
+Use the shortcode `[gallery_uploader]` to display the gallery upload and management UI on any page.
+
+The plugin stores uploaded images under `wp-content/uploads/twmg/` and automatically generates seven day public links for each gallery.


### PR DESCRIPTION
## Summary
- create `2-way-media-gallery` WordPress plugin
- implement upload and gallery management shortcode
- add JS and CSS for drag & drop uploading and gallery display
- document installation and usage in README

## Testing
- `php -l 2-way-media-gallery/2-way-media-gallery.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd11dfb2c8326b47df95d98750a02